### PR TITLE
Update readme for Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/harvesthub/gardenhub/badge.svg)](https://snyk.io/test/github/harvesthub/gardenhub)
 [![Requirements Status](https://requires.io/github/HarvestHub/GardenHub/requirements.svg?branch=master)](https://requires.io/github/HarvestHub/GardenHub/requirements/?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/gardenhub/badge/?version=latest)](http://gardenhub.readthedocs.io/en/latest/?badge=latest)
+[![Docker Automated build](https://img.shields.io/docker/automated/harvesthub/gardenhub.svg)](https://hub.docker.com/r/harvesthub/gardenhub/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Matrix ID](https://img.shields.io/badge/matrix-%23gardenhub%3Amatrix.org-brightgreen.svg)](https://riot.im/app/#/room/#gardenhub:matrix.org)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GardenHub Promo Banner](gardenhub-promo.png)
+![GardenHub Promo Banner](https://raw.githubusercontent.com/HarvestHub/GardenHub/master/gardenhub-promo.png)
 
 [![Build Status](https://travis-ci.org/HarvestHub/GardenHub.svg?branch=master)](https://travis-ci.org/HarvestHub/GardenHub)
 [![Coverage Status](https://coveralls.io/repos/github/HarvestHub/GardenHub/badge.svg?branch=master)](https://coveralls.io/github/HarvestHub/GardenHub?branch=master)


### PR DESCRIPTION
We have automated Docker builds now, but the promo banner doesn't show up unless we directly link to it. Also, I added a badge linking to the Docker Hub page so people can more easily find it.