### PR TITLE
Have dev.sh pull media using s3

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -91,7 +91,9 @@ function pulldb() {
 # Pull media files from staging
 function pullmedia() {
   mkdir -p media
-  scp -r root@candlewaster.co:/var/lib/dokku/data/storage/${app}/media/* media
+  ssh gardenhub@candlewaster.co s3cmd get s3://gardenhub/gardenhub --recursive
+  rsync -av gardenhub@candlewaster.co:~/gardenhub/ ./media
+  ssh gardenhub@candlewaster.co rm -r gardenhub
 }
 
 # Serve docs


### PR DESCRIPTION
I've updated the staging site to basically reflect the production site in terms of settings and code. It has separate data, but that's fine.

Since we're using DigitalOcean spaces, we want to be able to pull media from them so when we're using local dev settings we can access those media files. This change achieves that.