### PR TITLE
Make dev.sh rely on docker-compose, fixes #149

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.5-alpine
 
 MAINTAINER HarvestHub
 
+# Makes manage.py commands able to show output
+ENV PYTHONUNBUFFERED 1
+
 ADD requirements.txt /requirements.txt
 
 RUN set -ex \

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ GardenHub provides a script called `dev.sh` to make local development easy. As l
 You will need the following packages installed to develop on GardenHub:
 
 * docker-ce
+* docker-compose
 * git
 * bash
 
@@ -49,6 +50,12 @@ sudo usermod -aG docker $(whoami)
 ```
 
 Finally, log out and back into your computer, and then head to the next section.
+
+#### Installing Docker Compose
+
+You will also need [Docker Compose](https://docs.docker.com/compose/install/#install-compose) for local development. Check if you already have it by typing `docker-compose version`.
+
+If you need to install it, follow the link and select your platform for specific instructions.
 
 ### Starting the development server
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,91 +1,20 @@
-app="gardenhub"
-
-# Build the docker container
-function build() {
-  echo "Building $app image"
-  docker build -t $app .
-}
-
-# Test whether the database is up
-function test_db() {
-  docker run --rm --network=host \
-    -e PGPASSWORD=$app \
-    postgres:10-alpine \
-    sh -c 'psql -h "0.0.0.0" -p '$db_port' -U "postgres" -c "\q"' &> /dev/null
-}
-
-# Start database container
-function start_db() {
-  # Create volume
-  docker volume create ${app}_pgdata
-  # Run Postgres
-  docker run --rm \
-    --name ${app}_db \
-    -v ${app}_pgdata:/var/lib/postgresql/data \
-    -p 0:5432 \
-    -e POSTGRES_PASSWORD=$app \
-    -d postgres:10-alpine $@
-  # Get DB port
-  regex="5432\/tcp -> 0\.0\.0\.0:([0-9]+)"
-  if [[ $(docker port ${app}_db) =~ $regex ]]
-  then
-      db_port="${BASH_REMATCH[1]}"
-      echo "Database is listening at port ${db_port}"
-  fi
-  # Wait for db before continuing
-  until test_db -eq 0; do
-    echo "Postgres is still starting up..."
-    sleep 1
-  done
-}
-
-# Stop the database container if it's not in use
-function stop_db() {
-  # Get number of app containers running
-  n=$(docker ps -f ancestor=$app --format '{{.Names}}' | wc -l)
-  # If 0 app containers are running, stop the db container
-  if [ $n -eq 0 ]; then
-    docker stop ${app}_db 2> /dev/null
-  fi
-}
-
-function manage_py() {
-  # Build the image if it isn't already
-  if ! docker image inspect $app > /dev/null; then
-    build
-  fi
-  # Start Postgres first if it isn't
-  start_db 2> /dev/null
-  # Run the app container
-  docker run --rm -it \
-    -p 8000:8000 \
-    --network=host \
-    -e PYTHONUNBUFFERED=0 \
-    -e DATABASE_URL="postgres://postgres:${app}@0.0.0.0:${db_port}/postgres" \
-    -v $(pwd):/app \
-    $app python manage.py $@
-  # Stop Postgres if it's no longer being used
-  stop_db
-}
+set -e
 
 # Run containers
 function start() {
-  manage_py migrate
-  manage_py runserver
+  docker-compose run --rm web python manage.py migrate
+  docker-compose up
 }
 
 # Pull database from staging to local
 function pulldb() {
-  docker stop ${app}_db 2> /dev/null # Force stop db
-  docker volume rm ${app}_pgdata
-  docker volume create ${app}_pgdata
-  ssh dokku@candlewaster.co postgres:export $app > db.dump
-  start_db
-  docker cp db.dump ${app}_db:/db.dump
-  docker exec -it ${app}_db sh -c \
-    "pg_restore -U postgres -d postgres /db.dump && rm /db.dump"
+  ssh dokku@candlewaster.co postgres:export gardenhub > db.dump
+  docker-compose down -v
+  docker-compose up -d
+  docker-compose run --rm -v $(pwd)/db.dump:/db.dump db sh -c \
+    "pg_restore -U postgres -h db -d postgres /db.dump"
+  docker-compose down
   echo "Successfully restored staging database!"
-  stop_db
 }
 
 # Pull media files from staging
@@ -111,11 +40,11 @@ case $1 in
   setup)
     sudo sh -c "wget -nv -O - https://get.docker.com/ | sh"
     ;;
-  build) build ;;
+  build) docker-compose build ;;
   start) start ;;
   manage.py)
     shift
-    manage_py $@
+    docker-compose --rm run web python manage.py $@
     ;;
   docs) servedocs ;;
   pulldb) pulldb ;;
@@ -126,11 +55,11 @@ case $1 in
     echo "usage: ./dev.sh <command> [<args>]"
     echo ""
     echo "Commands:"
-    echo "    start      Run the app for local development on port 8000."
+    echo "    start      Run the app for local development on port 5000."
     echo "    build      Manually (re)build the app container."
     echo "    manage.py  Runs python manage.py <args> in the app container."
     echo "    setup      Installs Docker."
-    echo "    docs       Runs a local server for the docs on port 8000."
+    echo "    docs       Runs a local server for the docs on port 5000."
     echo ""
     echo "Staging sync (permission required):"
     echo "    pulldb     Downloads db from staging."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  db:
+    image: postgres:10-alpine
+    volumes:
+      - db:/var/lib/postgresql/data/
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:5000
+    volumes:
+      - .:/app
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+
+volumes:
+  db:

--- a/settings/base.py
+++ b/settings/base.py
@@ -71,7 +71,10 @@ WSGI_APPLICATION = 'wsgi.application'
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 
 DATABASES = {
-    'default': dj_database_url.config(conn_max_age=600)
+    'default': dj_database_url.config(
+        conn_max_age=600,
+        default='postgres://postgres@db:5432/postgres'
+    )
 }
 
 

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -9,6 +9,7 @@ TEMPLATES[0]['OPTIONS']['debug'] = True  # noqa
 SECRET_KEY = 'CHANGEME!!!'
 
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2')
+ALLOWED_HOSTS = ['*']
 
 BASE_URL = 'http://localhost:8000'
 


### PR DESCRIPTION
This is an unfortunate concession I've made to resolve #149. It makes things easier for us project maintainers to use docker-compose, but makes it a little harder for contributors to jump in. At this point it seems like a worthwhile trade-off since docker-ce 18 totally broke my setup and no one can contribute this way anyway.

Basically it cleans up `dev.sh`, makes it totally reliant on docker-compose, and instructions to install docker-compose are added to the readme.

This is probably a better path to go down, and we can experiment with making it easier to get compose installed later.