### PR TITLE
Update dependencies and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine
+FROM python:3.7-alpine
 
 MAINTAINER HarvestHub
 
@@ -42,7 +42,7 @@ RUN set -ex \
             | sort -u \
     )" \
     # Install Node and Less for compiling .less in development
-    && apk add --no-cache nodejs \
+    && apk add --no-cache npm \
     && npm install -g less \
     # Add the runtime dependencies we need to keep
     && apk add --virtual .python-rundeps $runDeps \

--- a/gardenhub/test_views.py
+++ b/gardenhub/test_views.py
@@ -23,7 +23,7 @@ class PlotCreateViewTestCase(TestCase):
         # Normal users can't access
         client.force_login(ActiveUserFactory())
         response = client.get(reverse('plot-create'))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
 
     def test_post(self):
         """ Test submit under ideal conditions """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
-django==2.0.3
+django==2.1
 django-compressor==2.2
-Pillow==5.0.0
-whitenoise==3.3.1
+Pillow==5.2.0
+whitenoise==4.0
 sorl-thumbnail==12.4.1
-psycopg2==2.7.4
+psycopg2==2.7.5
 dj-database-url==0.5.0
 django-phonenumber-field==2.0.0
 django-storages==1.6.6
-boto3==1.6.19
+boto3==1.7.74
 
 # Tests
-factory_boy==2.10.0
+factory_boy==2.11.1
 
 # Docs
-Sphinx==1.7.2
+Sphinx==1.7.6
 sphinx-autobuild==0.7.1
-sphinxcontrib-django==0.3.1
-sphinx_rtd_theme==0.2.5b2
+sphinxcontrib-django==0.4
+sphinx_rtd_theme==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,15 @@ whitenoise==4.0
 sorl-thumbnail==12.4.1
 psycopg2==2.7.5
 dj-database-url==0.5.0
-django-phonenumber-field==2.0.0
+django-phonenumber-field==2.0.1
 django-storages==1.6.6
-boto3==1.7.74
+boto3==1.8.4
 
 # Tests
 factory_boy==2.11.1
 
 # Docs
-Sphinx==1.7.6
+Sphinx==1.7.8
 sphinx-autobuild==0.7.1
 sphinxcontrib-django==0.4
 sphinx_rtd_theme==0.4.1


### PR DESCRIPTION
This updates everything to the latest version, getting rid of the few vulnerabilities in this project.

I also had to update a test, because Django 2.1 now returns an HTTP 403 instead of a 302 on AccessMixin's when the user isn't logged in. See: https://github.com/django/django/commit/9b1125bfc7e2dc747128e6e7e8a2259ff1a7d39f

> **Version changed 2.1**
> In older versions, authenticated users who lacked permissions were
> redirected to the login page (which resulted in a loop) instead of
> receiving an HTTP 403 Forbidden response.